### PR TITLE
开发环境搭建、修复遇到的问题

### DIFF
--- a/doc/chinese/01-开发环境搭建.md
+++ b/doc/chinese/01-开发环境搭建.md
@@ -141,15 +141,15 @@ $ docker-compose -f docker-compose-env.yml up -d
 进入容器
 
 ```shell
-$ docker exec -it kafka /bin/sh
+$ docker exec -it kafka /bin/sh &&
 $ cd /opt/kafka/bin/
 ```
 
 创建2个topic
 
 ```shell
-$ ./kafka-topics.sh --create --zookeeper zookeeper:2181 --replication-factor 1 -partitions 1 --topic looklook-log
-$ ./kafka-topics.sh --create --zookeeper zookeeper:2181 --replication-factor 1 -partitions 1 --topic payment-update-paystatus-topic
+$ ./kafka-topics.sh --create --bootstrap-server kafka:9092 --replication-factor 1 --partitions 1 --topic looklook-log
+$ ./kafka-topics.sh --create --bootstrap-server kafka:9092 --replication-factor 1 --partitions 1 --topic payment-update-paystatus-topic
 ```
 
 looklook-log ： 日志收集使用的
@@ -163,7 +163,7 @@ payment-update-paystatus-topic ： 支付成功通知所有订阅者
 本地工具连接mysql的话要先进入容器，给root设置下远程连接权限
 
 ```shell
-$ docker exec -it mysql mysql -uroot -p
+$ docker exec -it mysql mysql -uroot -pPXDN93VRKUm8TeE7
 ##输入密码：PXDN93VRKUm8TeE7
 $ use mysql;
 $ update user set host='%' where user='root';
@@ -172,13 +172,13 @@ $ FLUSH PRIVILEGES;
 
 
 
-创建数据库looklook_order && 导入deploy/sql/looklook_order.sql数据
+创建数据库 looklook_order && 导入deploy/sql/looklook_order.sql数据
 
-创建数据库looklook_payment && 导入deploy/sql/looklook_payment.sql数据
+创建数据库 looklook_payment && 导入deploy/sql/looklook_payment.sql数据
 
-创建数据库looklook_travel && 导入deploy/sql/looklook_travel.sql数据
+创建数据库 looklook_travel && 导入deploy/sql/looklook_travel.sql数据
 
-创建数据库looklook_usercenter && 导入looklook_usercenter.sql数据
+创建数据库 looklook_usercenter && 导入looklook_usercenter.sql数据
 
 
 

--- a/docker-compose-env.yml
+++ b/docker-compose-env.yml
@@ -1,5 +1,3 @@
-version: '3'
-
 ######## 项目依赖的环境，启动项目之前要先启动此环境 #######
 ######## The environment that the project depends on, starting this environment before starting the project #######
 
@@ -226,6 +224,7 @@ services:
 
 networks:
   looklook_net:
+    external: true
     driver: bridge
     ipam:
       config:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3'
-
 ######## app下api+rpc ,  Before starting this project, start the environment that the project depends on docker-compose-env.yml #######
 
 services:
@@ -43,6 +41,7 @@ services:
 
 networks:
   looklook_net:
+    external: true
     driver: bridge
     ipam:
       config:

--- a/note.md
+++ b/note.md
@@ -1,0 +1,36 @@
+## 测试环境启动命令变更
+
+`docker network create looklook_net`
+
+`docker-compose -f docker-compose-env.yml start`
+`docker-compose -f docker-compose.yml start`
+
+`docker-compose  -f docker-compose-env.yml stop`
+`docker-compose  -f docker-compose.yml stop`
+
+
+./kafka-topics.sh --create --bootstrap-server kafka:9092 --replication-factor 1 --partitions 1 --topic looklook-log
+./kafka-topics.sh --create --bootstrap-server kafka:9092 --replication-factor 1 --partitions 1 --topic payment-update-paystatus-topic
+
+
+
+yugu@yugudeMacBook-Pro go-zero-looklook % docker exec -it kafka /bin/sh
+/ $ cd /opt/kafka/bin/
+/opt/kafka/bin $ ./kafka-topics.sh --create --zookeeper zookeeper:2181 --replication-factor 1 -partitions 1 --topic looklook-log
+zookeeper is not a recognized option
+joptsimple.UnrecognizedOptionException: zookeeper is not a recognized option
+at joptsimple.OptionException.unrecognizedOption(OptionException.java:108)
+at joptsimple.OptionParser.handleLongOptionToken(OptionParser.java:510)
+at joptsimple.OptionParserState$2.handleArgument(OptionParserState.java:56)
+at joptsimple.OptionParser.parse(OptionParser.java:396)
+at org.apache.kafka.tools.TopicCommand$TopicCommandOptions.<init>(TopicCommand.java:830)
+at org.apache.kafka.tools.TopicCommand.execute(TopicCommand.java:100)
+at org.apache.kafka.tools.TopicCommand.mainNoExit(TopicCommand.java:90)
+at org.apache.kafka.tools.TopicCommand.main(TopicCommand.java:85)
+
+/opt/kafka/bin $ ./kafka-topics.sh --create --bootstrap-server kafka:9092 --replication-factor 1 --partitions 1 --topic looklook-log
+Error while executing topic command : Topic 'looklook-log' already exists.
+[2024-12-04 06:23:49,820] ERROR org.apache.kafka.common.errors.TopicExistsException: Topic 'looklook-log' already exists.
+(org.apache.kafka.tools.TopicCommand)
+/opt/kafka/bin $ ./kafka-topics.sh --create --bootstrap-server kafka:9092 --replication-factor 1 --partitions 1 --topic payment-update-paystatus-topic
+Created topic payment-update-paystatus-topic.


### PR DESCRIPTION
kafka3.7版本创建topic不再支持--zookeeper参数，--zookeeper zookeeper:2181需要改为--bootstrap-server kafka:9092

docker-compose不再支持version定义，删除了version字段
且network需要指明external为true